### PR TITLE
Add `open_api_test` to the list of tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,8 @@ dmypy.json
 .project
 .pydevproject
 
+# JetBrains IDE
+/.idea
+
+# Open API Schema file
+/open_api.yaml

--- a/lm_test/tests/open_api_test.py
+++ b/lm_test/tests/open_api_test.py
@@ -1,0 +1,73 @@
+"""Test all API endpoints."""
+import json
+import open_api_tools.test.full_test as full_test
+import lm_test.base.test_base as test_base
+
+"""
+open_api_tools library is required for this test to work
+It, along with the installation instructions can be found here:
+https://github.com/specify/open_api_tools/
+
+Also, the location of an `open_api.yaml` schema file needs to be
+provided as the first argument
+"""
+
+# .............................................................................
+
+
+class OpenAPITest(test_base.LmTest):
+    """Test checking cpu usage."""
+    # .............................
+    def __init__(
+        self,
+        # location of the yaml OpenAPI schema file
+        open_api_schema_location: str,
+        # Maximum number of requests to send to each endpoint
+        max_urls_per_endpoint: int = 40,
+        # Stop testing after this many failed requests
+        failed_request_limit: int = 10,
+        delay_time: int = 0,
+        delay_interval: int = 3600
+    ):
+        test_base.LmTest.__init__(self, delay_time=delay_time)
+        self._open_api_schema_location = open_api_schema_location
+        self._max_urls_per_endpoint = max_urls_per_endpoint
+        self._failed_request_limit = failed_request_limit
+        self._delay_interval = delay_interval
+
+    # .............................
+    def __repr__(self):
+        return ('Validating API against the OpenAPI schema (%d urls per ' +
+                'endpoint)') % self._max_urls_per_endpoint
+
+    # .............................
+    def run_test(self):
+        """Run the test."""
+
+        error_messages = []
+
+        def error_callback(*args):
+            nonlocal error_messages
+            error_messages.append(args)
+
+        full_test.test(
+            self._open_api_schema_location,
+            error_callback,
+            self._max_urls_per_endpoint,
+            self._failed_request_limit,
+            {}  # TODO: provide parameter constraints
+        )
+        self.add_new_test(
+            OpenAPITest(
+                self._open_api_schema_location,
+                self._max_urls_per_endpoint,
+                self._failed_request_limit,
+                delay_time=self._delay_interval,
+                delay_interval=self._delay_interval
+            )
+        )
+
+        if error_messages:
+            raise test_base.LmTestFailure(
+                json.dumps(error_messages, indent=4)
+            )

--- a/scripts/run_controller.py
+++ b/scripts/run_controller.py
@@ -29,13 +29,13 @@ TESTS_TO_RUN = [
     SimulatedSubmissionTest(True, -10, True),  # Times out
     # Longer wait but everything passes
     SimulatedSubmissionTest(True, 400, True),
-    OpenAPITest(
-        os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            '../open_api.yaml'
-        ),
-        max_urls_per_endpoint=10
-    )
+    #OpenAPITest(
+    #    os.path.join(
+    #        os.path.dirname(os.path.abspath(__file__)),
+    #        '../open_api.yaml'
+    #    ),
+    #    max_urls_per_endpoint=10
+    #)
 ]
 
 

--- a/scripts/run_controller.py
+++ b/scripts/run_controller.py
@@ -1,5 +1,6 @@
 """Script to run test controller."""
 import argparse
+import os
 import sys
 
 from lm_test.base.daemon import DaemonCommands
@@ -10,22 +11,31 @@ from lm_test.tests.memory_usage_test import MemoryUsageTest
 from lm_test.tests.lm_client_test import LmClientTest
 from lm_test.tests.ot_client_test import OpenTreeTest
 from lm_test.tests.simulated_test import SimulatedSubmissionTest
+from lm_test.tests.open_api_test import OpenAPITest
 
 
 # Note: Edit this for now.  We will need a better mechanism for adding tests
 TESTS_TO_RUN = [
-    #PytestTest('/home/cjgrady/git/lm_client/'),
+    # PytestTest('/home/cjgrady/git/lm_client/'),
     MemoryUsageTest(60, 90, delay_interval=600),
     CPUUsageTest(50, 90, delay_interval=300),
     DiskUsageTest('/DATA/', 50, 80, delay_interval=3600),
     DiskUsageTest('/', 50, 90, delay_interval=3600),
     LmClientTest(delay_interval=600),
     OpenTreeTest(),
-    SimulatedSubmissionTest(True, 75, True), # Everything passes
-    SimulatedSubmissionTest(True, 75, False), # Fails to validate
-    SimulatedSubmissionTest(False, 75, True), # Fails to submit
-    SimulatedSubmissionTest(True, -10, True), # Times out
-    SimulatedSubmissionTest(True, 400, True) # Longer wait but everything passes
+    SimulatedSubmissionTest(True, 75, True),  # Everything passes
+    SimulatedSubmissionTest(True, 75, False),  # Fails to validate
+    SimulatedSubmissionTest(False, 75, True),  # Fails to submit
+    SimulatedSubmissionTest(True, -10, True),  # Times out
+    # Longer wait but everything passes
+    SimulatedSubmissionTest(True, 400, True),
+    OpenAPITest(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            '../open_api.yaml'
+        ),
+        max_urls_per_endpoint=10
+    )
 ]
 
 


### PR DESCRIPTION
```
open_api_tools library is required for this test to work
It, along with the installation instructions can be found here:
https://github.com/specify/open_api_tools/
Also, the location of an `open_api.yaml` schema file needs to be
provided as the first argument of the test class
```